### PR TITLE
added links = "enet" to Cargo.toml to allow build script override (for windows)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Low level bindings to the enet C library"
 license = "MIT"
 repository = "https://github.com/ruabmbua/enet-sys"
 build = "src/build.rs"
+links = "enet"
 
 [dependencies]
 libc = "0.2.7"


### PR DESCRIPTION
I added `links = "enet"` to Cargo.toml to allow a [build script override](http://doc.crates.io/build-script.html#overriding-build-scripts) for enet since the build.rs script doesn't support building for msvc.
