### PR TITLE
set bindgen builder option derive debug to false

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,7 @@ fn main() {
     let bindings = bindgen::Builder::default()
         .clang_arg("-Ivendor/enet/include/")
         .header("wrapper.h")
+        .derive_debug(false)
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
Should fix the errors in bindgen.rs described in #5 and #7