### PR TITLE
Working build with MSVC toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Roland Ruckerbauer <roland.rucky@gmail.com>"]
 description = "Low level bindings to the enet C library"
 license = "MIT"
 repository = "https://github.com/ruabmbua/enet-sys"
+links = "enet"
 build = "build.rs"
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ use cmake::Config;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
+    let is_debug = env::var("DEBUG").unwrap() == "true";
     let bindings = bindgen::Builder::default()
         .clang_arg("-Ivendor/enet/include/")
         .header("wrapper.h")
@@ -26,10 +27,14 @@ fn main() {
 
     eprintln!("LUL: {}", dst.display());
 
-    println!("cargo:rustc-link-search=native={}/build", dst.display());
-    println!("cargo:rustc-link-lib=static=enet");
-
     if target.contains("windows") {
-        println!("cargo:rustc-link-lib=static=winmm");
+        if is_debug {
+            println!("cargo:rustc-link-search=native={}/build/Debug", dst.display());
+        } else {
+            println!("cargo:rustc-link-search=native={}/build/Release", dst.display());
+        }
+    } else {
+        println!("cargo:rustc-link-search=native={}", dst.display());
     }
+    println!("cargo:rustc-link-lib=static=enet");
 }

--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,7 @@ fn main() {
         }
         println!("cargo:rustc-link-lib=dylib=winmm");
     } else {
-        println!("cargo:rustc-link-search=native={}", dst.display());
+        println!("cargo:rustc-link-search=native={}/build", dst.display());
     }
     println!("cargo:rustc-link-lib=static=enet");
 }

--- a/build.rs
+++ b/build.rs
@@ -33,6 +33,7 @@ fn main() {
         } else {
             println!("cargo:rustc-link-search=native={}/build/Release", dst.display());
         }
+        println!("cargo:rustc-link-lib=dylib=winmm");
     } else {
         println!("cargo:rustc-link-search=native={}", dst.display());
     }


### PR DESCRIPTION
This should build on Windows by issuing `> cargo build` command from the Windows command prompt with:

1. Installed Rust MSVC toolchain using rustup
2. Installed Windows Clang
3. Installed Windows CMake

<s>This also removes `winmm` from linking on Windows, as that was apparently only needed for MSYS2 which is not compatible with the MSVC toolchain. Maybe if there is a way to test whether MSYS or the GNU toolchain is being used it could be re-added but the goal was to use the MSVC toolchain so this is probably the better solution for now.</s>