### PR TITLE
Fix windows build (mingw)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,6 @@ use std::path::PathBuf;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
-    let is_debug = env::var("DEBUG").unwrap() == "true";
     let bindings = bindgen::Builder::default()
         .clang_arg("-Ivendor/enet/include/")
         .header("wrapper.h")
@@ -23,25 +22,14 @@ fn main() {
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 
-    let dst = Config::new("vendor/enet").build_target("enet").build();
+    let dst = Config::new("vendor/enet").build();
 
     eprintln!("LUL: {}", dst.display());
 
     if target.contains("windows") {
-        if is_debug {
-            println!(
-                "cargo:rustc-link-search=native={}/build/Debug",
-                dst.display()
-            );
-        } else {
-            println!(
-                "cargo:rustc-link-search=native={}/build/Release",
-                dst.display()
-            );
-        }
         println!("cargo:rustc-link-lib=dylib=winmm");
-    } else {
-        println!("cargo:rustc-link-search=native={}/build", dst.display());
     }
+
+    println!("cargo:rustc-link-search=native={}/lib/static", dst.display());
     println!("cargo:rustc-link-lib=static=enet");
 }


### PR DESCRIPTION
cmake artifact path in build directory was not predictable. Use cmake install() rules instead which have predictable paths for artifacts

Also update enet to current master