### PR TITLE
fix: Update bindgen to resolve missing ENetHost fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ links = "enet"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.65.1"
+bindgen = "0.72.1"
 cmake = "0.1.44"


### PR DESCRIPTION
Generated bindings currently omit all fields in _ENetHost and some others. This PR simply updates bindgen to the latest version which resolves the issue.

Here's how the struct looks like before the update:

```rust
#[doc = " An ENet host for communicating with peers.\n\n No fields should be modified unless otherwise stated.\n\n@sa enet_host_create()\n@sa enet_host_destroy()\n@sa enet_host_connect()\n@sa enet_host_service()\n@sa enet_host_flush()\n@sa enet_host_broadcast()\n@sa enet_host_compress()\n@sa enet_host_compress_with_range_coder()\n@sa enet_host_channel_limit()\n@sa enet_host_bandwidth_limit()\n@sa enet_host_bandwidth_throttle()"]
#[repr(C)]
#[derive(Copy, Clone)]
pub struct _ENetHost {
    pub _address: u8,
}
```

and this is the after:

```rust
#[doc = " An ENet host for communicating with peers.\n\n No fields should be modified unless otherwise stated.\n\n@sa enet_host_create()\n@sa enet_host_destroy()\n@sa enet_host_connect()\n@sa enet_host_service()\n@sa enet_host_flush()\n@sa enet_host_broadcast()\n@sa enet_host_compress()\n@sa enet_host_compress_with_range_coder()\n@sa enet_host_channel_limit()\n@sa enet_host_bandwidth_limit()\n@sa enet_host_bandwidth_throttle()"]
#[repr(C)]
#[derive(Copy, Clone)]
pub struct _ENetHost {
    pub socket: ENetSocket,
    #[doc = "< Internet address of the host"]
    pub address: ENetAddress,
    #[doc = "< downstream bandwidth of the host"]
    pub incomingBandwidth: enet_uint32,
    #[doc = "< upstream bandwidth of the host"]
    pub outgoingBandwidth: enet_uint32,
    pub bandwidthThrottleEpoch: enet_uint32,
    pub mtu: enet_uint32,
    pub randomSeed: enet_uint32,
    pub recalculateBandwidthLimits: ::std::os::raw::c_int,
    #[doc = "< array of peers allocated for this host"]
    pub peers: *mut ENetPeer,
    #[doc = "< number of peers allocated for this host"]
    pub peerCount: usize,
    #[doc = "< maximum number of channels allowed for connected peers"]
    pub channelLimit: usize,
    pub serviceTime: enet_uint32,
    pub dispatchQueue: ENetList,
    pub totalQueued: enet_uint32,
    pub packetSize: usize,
    pub headerFlags: enet_uint16,
    pub commands: [ENetProtocol; 32usize],
    pub commandCount: usize,
    pub buffers: [ENetBuffer; 65usize],
    pub bufferCount: usize,
    #[doc = "< callback the user can set to enable packet checksums for this host"]
    pub checksum: ENetChecksumCallback,
    pub compressor: ENetCompressor,
    pub packetData: [[enet_uint8; 4096usize]; 2usize],
    pub receivedAddress: ENetAddress,
    pub receivedData: *mut enet_uint8,
    pub receivedDataLength: usize,
    #[doc = "< total data sent, user should reset to 0 as needed to prevent overflow"]
    pub totalSentData: enet_uint32,
    #[doc = "< total UDP packets sent, user should reset to 0 as needed to prevent overflow"]
    pub totalSentPackets: enet_uint32,
    #[doc = "< total data received, user should reset to 0 as needed to prevent overflow"]
    pub totalReceivedData: enet_uint32,
    #[doc = "< total UDP packets received, user should reset to 0 as needed to prevent overflow"]
    pub totalReceivedPackets: enet_uint32,
    #[doc = "< callback the user can set to intercept received raw UDP packets"]
    pub intercept: ENetInterceptCallback,
    pub connectedPeers: usize,
    pub bandwidthLimitedPeers: usize,
    #[doc = "< optional number of allowed peers from duplicate IPs, defaults to ENET_PROTOCOL_MAXIMUM_PEER_ID"]
    pub duplicatePeers: usize,
    #[doc = "< the maximum allowable packet size that may be sent or received on a peer"]
    pub maximumPacketSize: usize,
    #[doc = "< the maximum aggregate amount of buffer space a peer may use waiting for packets to be delivered"]
    pub maximumWaitingData: usize,
}
```